### PR TITLE
ussologin: expose LoginWithToken

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -6,13 +6,14 @@ github.com/juju/schema	git	47d9b102199f4c67e5bfb28eb07bbe39411754fe	2016-01-19T2
 github.com/juju/testing	git	ee18040b46bb1f8c93438383bd51ec77eb8c02ab	2016-01-12T21:04:04Z
 github.com/juju/usso	git	6b745c7953441bc150da650ec9c0f5fd0d3901e1	2016-03-01T14:53:43Z
 github.com/juju/utils	git	0cac78a34dd1c42d2f2dc718c345fd13e3a264fc	2016-01-29T15:50:19Z
+github.com/juju/webbrowser	git	54b8c57083b4afb7dc75da7f13e2967b2606a507	2016-03-09T14:36:29Z
 github.com/julienschmidt/httprouter	git	77a895ad01ebc98a4dc95d8355bc825ce80a56f6	2015-10-13T22:55:20Z
 golang.org/x/crypto	git	aedad9a179ec1ea11b7064c57cbc6dc30d7724ec	2015-08-30T18:06:42Z
 golang.org/x/net	git	ea47fc708ee3e20177f3ca3716217c4ab75942cb	2015-08-29T23:03:18Z
 gopkg.in/check.v1	git	4f90aeace3a26ad7021961c297b22c42160c7b25	2016-01-05T16:49:36Z
 gopkg.in/errgo.v1	git	66cb46252b94c1f3d65646f54ee8043ab38d766c	2015-10-07T15:31:57Z
 gopkg.in/juju/environschema.v1	git	7359fc7857abe2b11b5b3e23811a9c64cb6b01e0	2015-11-04T11:58:10Z
-gopkg.in/macaroon-bakery.v1	git	a165ebf9a2ce170e430ee2360dab11c70c22062c	2016-01-19T15:40:20Z
+gopkg.in/macaroon-bakery.v1	git	6bce7a1e7399542cbafe16cbbb1dfe4591fcafe7	2016-03-16T08:34:47Z
 gopkg.in/macaroon.v1	git	ab3940c6c16510a850e1c2dd628b919f0f3f1464	2015-01-21T11:42:31Z
 gopkg.in/mgo.v2	git	4d04138ffef2791c479c0c8bbffc30b34081b8d9	2015-10-26T16:34:53Z
 gopkg.in/yaml.v2	git	53feefa2559fb8dfa8d81baad31be332c97d6c77	2015-09-24T14:23:14Z

--- a/ussologin/visitwebpage.go
+++ b/ussologin/visitwebpage.go
@@ -11,8 +11,6 @@ import (
 	"gopkg.in/errgo.v1"
 	"gopkg.in/juju/environschema.v1/form"
 	"gopkg.in/macaroon-bakery.v1/httpbakery"
-
-	"github.com/juju/idmclient"
 )
 
 // VisitWebPage returns a function which will allow authentication via USSO
@@ -22,33 +20,62 @@ import (
 // Existing oauth tokens can be obtained, or new ones stored If non-nil, the
 // given TokenStore is used to store the oauth token obtained during the login
 // process so that less interaction may be required in future.
-func VisitWebPage(filler form.Filler, client *http.Client, store TokenStore) func(*url.URL) error {
+func VisitWebPage(tokenName string, client *http.Client, filler form.Filler, store TokenStore) func(*url.URL) error {
+	visitor := NewVisitor(tokenName, filler, store)
 	return func(u *url.URL) error {
-		lm, err := idmclient.LoginMethods(client, u)
+		methodURLs, err := httpbakery.GetInteractionMethods(client, u)
 		if err != nil {
-			return err
+			return errgo.Mask(err)
 		}
-		if lm.UbuntuSSOOAuth != "" {
-			var tok *usso.SSOData
-			var err error
-			if store == nil {
-				tok, err := Login(filler)
-				if err != nil {
-					return err
-				}
-				return doSignedRequest(client, lm.UbuntuSSOOAuth, tok, u)
-			}
-			if tok, err = store.Get(); err != nil {
-				tok, err = Login(filler)
-				if err != nil {
-					return err
-				}
-				if err := store.Put(tok); err != nil {
-					return errgo.Notef(err, "cannot save token")
-				}
-			}
-			return doSignedRequest(client, lm.UbuntuSSOOAuth, tok, u)
-		}
-		return httpbakery.OpenWebBrowser(u)
+		return visitor.VisitWebPage(&httpbakery.Client{Client: client}, methodURLs)
 	}
+}
+
+// Visitor is an httpbakery.Visitor that will login using Ubuntu SSO
+// OAuth if it is supported by the discharger.
+type Visitor struct {
+	tokenName string
+	filler    form.Filler
+	store     TokenStore
+}
+
+// NewVisitor creates a new Visitor that will attempt to interact using
+// an Ubuntu SSO OAuth token. If there is a token stored in store then
+// that will be used. Otherwise filler will be used to ineract with the
+// user and the credentials will be sent to Ubuntu SSO to create a token
+// named tokenName. That token will be stored in store if possible and
+// used to interact with the discharger.
+func NewVisitor(tokenName string, filler form.Filler, store TokenStore) *Visitor {
+	return &Visitor{
+		tokenName: tokenName,
+		filler:    filler,
+		store:     store,
+	}
+}
+
+// VisitWebPage implements httpbakery.Visitor.VisitWebPage.
+func (v *Visitor) VisitWebPage(client *httpbakery.Client, methodURLs map[string]*url.URL) error {
+	if methodURLs["usso_oauth"] == nil {
+		return httpbakery.ErrMethodNotSupported
+	}
+	var tok *usso.SSOData
+	var err error
+	if v.store != nil {
+		// Ignore any error from the store, we'll attempt to get
+		// the token from Ubuntu SSO.
+		tok, _ = v.store.Get()
+	}
+	if tok == nil {
+		tok, err = GetToken(v.filler, v.tokenName)
+		if err != nil {
+			return errgo.Mask(err)
+		}
+		if v.store != nil {
+			// Ignore any error from the store, we can still
+			// log in, the user will just be prompted for
+			// credentials again next time.
+			v.store.Put(tok)
+		}
+	}
+	return LoginWithToken(client.Client, methodURLs["usso_oauth"].String(), tok)
 }


### PR DESCRIPTION
Expose LoginWithToken to make it easier to create custom VisitWebPage
functions that make decisions after LoginMethods have been retrieved.
Also rename the Login function to GetToken and make the service name
sent to Ubuntu SSO a parameter.