### PR TITLE
ussologin: pass thorugh Ubuntu SSO Errors

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -4,7 +4,7 @@ github.com/juju/loggo	git	8477fc936adf0e382d680310047ca27e128a309a	2015-05-27T03
 github.com/juju/names	git	e287fe4ae0dbda220cace3ed0e35cda4796c1aa3	2015-10-22T17:21:35Z
 github.com/juju/schema	git	47d9b102199f4c67e5bfb28eb07bbe39411754fe	2016-01-19T21:19:26Z
 github.com/juju/testing	git	ee18040b46bb1f8c93438383bd51ec77eb8c02ab	2016-01-12T21:04:04Z
-github.com/juju/usso	git	6b745c7953441bc150da650ec9c0f5fd0d3901e1	2016-03-01T14:53:43Z
+github.com/juju/usso	git	68a59c96c178fbbad65926e7f93db50a2cd14f33	2016-04-01T10:44:24Z
 github.com/juju/utils	git	0cac78a34dd1c42d2f2dc718c345fd13e3a264fc	2016-01-29T15:50:19Z
 github.com/juju/webbrowser	git	54b8c57083b4afb7dc75da7f13e2967b2606a507	2016-03-09T14:36:29Z
 github.com/julienschmidt/httprouter	git	77a895ad01ebc98a4dc95d8355bc825ce80a56f6	2015-10-13T22:55:20Z
@@ -13,7 +13,7 @@ golang.org/x/net	git	ea47fc708ee3e20177f3ca3716217c4ab75942cb	2015-08-29T23:03:1
 gopkg.in/check.v1	git	4f90aeace3a26ad7021961c297b22c42160c7b25	2016-01-05T16:49:36Z
 gopkg.in/errgo.v1	git	66cb46252b94c1f3d65646f54ee8043ab38d766c	2015-10-07T15:31:57Z
 gopkg.in/juju/environschema.v1	git	7359fc7857abe2b11b5b3e23811a9c64cb6b01e0	2015-11-04T11:58:10Z
-gopkg.in/macaroon-bakery.v1	git	6bce7a1e7399542cbafe16cbbb1dfe4591fcafe7	2016-03-16T08:34:47Z
+gopkg.in/macaroon-bakery.v1	git	fddb3dcd74806133259879d033fdfe92f9e67a8a	2016-04-01T12:14:21Z
 gopkg.in/macaroon.v1	git	ab3940c6c16510a850e1c2dd628b919f0f3f1464	2015-01-21T11:42:31Z
 gopkg.in/mgo.v2	git	4d04138ffef2791c479c0c8bbffc30b34081b8d9	2015-10-26T16:34:53Z
 gopkg.in/yaml.v2	git	53feefa2559fb8dfa8d81baad31be332c97d6c77	2015-09-24T14:23:14Z

--- a/ussologin/ussologin.go
+++ b/ussologin/ussologin.go
@@ -37,7 +37,8 @@ var (
 // information to obtain an OAuth token from Ubuntu SSO. The returned
 // token can subsequently be used with LoginWithToken to perform a login.
 // The tokenName argument is used as the name of the generated token in
-// Ubuntu SSO.
+// Ubuntu SSO. If Ubuntu SSO returned an error when trying to retrieve
+// the token the error will have a cause of type *usso.Error.
 func GetToken(filler form.Filler, tokenName string) (*usso.SSOData, error) {
 	login, err := filler.Fill(loginForm)
 	if err != nil {
@@ -51,7 +52,7 @@ func GetToken(filler form.Filler, tokenName string) (*usso.SSOData, error) {
 	)
 
 	if err != nil {
-		return nil, errgo.Notef(err, "cannot get token")
+		return nil, errgo.NoteMask(err, "cannot get token", isUSSOError)
 	}
 	return tok, nil
 }
@@ -165,4 +166,10 @@ func (f *FileTokenStore) Get() (*usso.SSOData, error) {
 		return nil, errgo.Notef(err, "cannot unmarshal token")
 	}
 	return &tok, nil
+}
+
+// isUSSOError determines if err represents an error of type *usso.Error.
+func isUSSOError(err error) bool {
+	_, ok := err.(*usso.Error)
+	return ok
 }

--- a/ussologin/visitwebpage.go
+++ b/ussologin/visitwebpage.go
@@ -53,7 +53,11 @@ func NewVisitor(tokenName string, filler form.Filler, store TokenStore) *Visitor
 	}
 }
 
-// VisitWebPage implements httpbakery.Visitor.VisitWebPage.
+// VisitWebPage implements httpbakery.Visitor.VisitWebPage by attempting
+// to obtain an Ubuntu SSO OAuth token and use that to sign a request to
+// the identity manager. If Ubuntu SSO returns an error when attempting
+// to obtain the token the error returned will have a cause of type
+// *usso.Error.
 func (v *Visitor) VisitWebPage(client *httpbakery.Client, methodURLs map[string]*url.URL) error {
 	if methodURLs["usso_oauth"] == nil {
 		return httpbakery.ErrMethodNotSupported
@@ -68,7 +72,7 @@ func (v *Visitor) VisitWebPage(client *httpbakery.Client, methodURLs map[string]
 	if tok == nil {
 		tok, err = GetToken(v.filler, v.tokenName)
 		if err != nil {
-			return errgo.Mask(err)
+			return errgo.Mask(err, isUSSOError)
 		}
 		if v.store != nil {
 			// Ignore any error from the store, we can still


### PR DESCRIPTION
Pass through any errors that are returned by Ubuntu SSO when retrieving
a token.