### PR TITLE
idmtest: do not overwrite groups in AddUser

### DIFF
--- a/idmtest/idmtest_test.go
+++ b/idmtest/idmtest_test.go
@@ -94,3 +94,20 @@ func (*suite) TestGroups(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	c.Assert(groups, gc.HasLen, 0)
 }
+
+func (s *suite) TestAddUserWithExistingGroups(c *gc.C) {
+	srv := idmtest.NewServer()
+	srv.AddUser("alice", "anteaters")
+	srv.AddUser("alice")
+	srv.AddUser("alice", "goof", "anteaters")
+
+	client := idmclient.New(idmclient.NewParams{
+		BaseURL: srv.URL.String(),
+		Client:  srv.Client("alice"),
+	})
+	groups, err := client.UserGroups(&idmparams.UserGroupsRequest{
+		Username: "alice",
+	})
+	c.Assert(err, gc.IsNil)
+	c.Assert(groups, jc.DeepEquals, []string{"anteaters", "goof"})
+}


### PR DESCRIPTION
This means that it's possible to ensure that a user is a member of
a group without removing their existing group membership.
Note that this is in a testing context.