### PR TITLE
integrate pemission checker into Client

### DIFF
--- a/client.go
+++ b/client.go
@@ -4,13 +4,16 @@
 package idmclient
 
 import (
-	"io"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/juju/httprequest"
 	"gopkg.in/errgo.v1"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery/checkers"
 	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery/agent"
 
 	"github.com/juju/idmclient/params"
 )
@@ -25,53 +28,159 @@ const (
 // Client represents the client of an identity server.
 type Client struct {
 	client
+
+	// permChecker is used to check group membership.
+	// It is only non-zero when groups are enabled.
+	permChecker *PermChecker
 }
+
+var _ IdentityClient = (*Client)(nil)
 
 // NewParams holds the parameters for creating a new client.
 type NewParams struct {
+	// BaseURL holds the URL of the identity manager.
 	BaseURL string
-	Client  *httpbakery.Client
 
-	// AuthUsername holds the username for admin login.
-	AuthUsername string
+	// Client holds the client to use to make requests
+	// to the identity manager.
+	Client *httpbakery.Client
 
-	// AuthPassword holds the password for admin login.
-	AuthPassword string
+	// AgentUsername holds the username for group-fetching authorization.
+	// If this is empty, no group information will be provided.
+	// The agent key is expected to be held inside the Client.
+	AgentUsername string
+
+	// CacheTime holds the maximum duration for which
+	// group membership information will be cached.
+	// If this is zero, group membership information will not be cached.
+	CacheTime time.Duration
 }
 
 // New returns a new client.
-func New(p NewParams) *Client {
+func New(p NewParams) (*Client, error) {
 	var c Client
-	c.Client.BaseURL = p.BaseURL
-	if p.AuthUsername != "" {
-		c.Client.Doer = &basicAuthClient{
-			client:   p.Client,
-			user:     p.AuthUsername,
-			password: p.AuthPassword,
-		}
-	} else {
-		c.Client.Doer = p.Client
+	u, err := url.Parse(p.BaseURL)
+	if p.BaseURL == "" || err != nil {
+		return nil, errgo.Newf("bad identity client base URL %q", p.BaseURL)
 	}
+	c.Client.BaseURL = p.BaseURL
+	if p.AgentUsername != "" {
+		if err := agent.SetUpAuth(p.Client, u, p.AgentUsername); err != nil {
+			return nil, errgo.Notef(err, "cannot set up agent authentication")
+		}
+		c.permChecker = NewPermChecker(&c, p.CacheTime)
+	}
+	c.Client.Doer = p.Client
 	c.Client.UnmarshalError = httprequest.ErrorUnmarshaler(new(params.Error))
-	return &c
+	return &c, nil
 }
 
-// basicAuthClient wraps a bakery.Client, adding a basic auth
-// header to every request.
-type basicAuthClient struct {
-	client   *httpbakery.Client
-	user     string
-	password string
+// IdentityCaveat implements IdentityClient.IdentityCaveat.
+func (c *Client) IdentityCaveats() []checkers.Caveat {
+	return []checkers.Caveat{
+		checkers.NeedDeclaredCaveat(
+			checkers.Caveat{
+				Location:  c.Client.BaseURL,
+				Condition: "is-authenticated-user",
+			},
+			"username",
+		),
+	}
 }
 
-func (c *basicAuthClient) Do(req *http.Request) (*http.Response, error) {
-	req.SetBasicAuth(c.user, c.password)
-	return c.client.Do(req)
+// DeclaredIdentity implements IdentityClient.DeclaredIdentity.
+// On success, it returns a value of type *User.
+func (c *Client) DeclaredIdentity(declared map[string]string) (Identity, error) {
+	username := declared["username"]
+	if username == "" {
+		return nil, errgo.Newf("no declared user name in %q", declared)
+	}
+	return &User{
+		client:   c,
+		username: username,
+	}, nil
 }
 
-func (c *basicAuthClient) DoWithBody(req *http.Request, r io.ReadSeeker) (*http.Response, error) {
-	req.SetBasicAuth(c.user, c.password)
-	return c.client.DoWithBody(req, r)
+// UserDeclaration returns a first party caveat that can be used
+// by an identity manager to declare an identity on a discharge
+// macaroon.
+func UserDeclaration(username string) checkers.Caveat {
+	return checkers.DeclaredCaveat("username", username)
+}
+
+// CacheEvict evicts username from the user info cache.
+func (c *Client) CacheEvict(username string) {
+	if c.permChecker != nil {
+		c.permChecker.CacheEvict(username)
+	}
+}
+
+// CacheEvictAll evicts everything from the user info cache.
+func (c *Client) CacheEvictAll() {
+	if c.permChecker != nil {
+		c.permChecker.CacheEvictAll()
+	}
+}
+
+// User is an implementation of Identity that also implements
+// IDM-specific methods for obtaining the user name and
+// group membership information.
+type User struct {
+	client   *Client
+	username string
+}
+
+// Username returns the user name of the user.
+func (u *User) Username() (string, error) {
+	return u.username, nil
+}
+
+// Groups returns all the groups that the user
+// is a member of.
+//
+// Note: use of this method should be avoided if
+// possible, as a user may potentially be in huge
+// numbers of groups.
+func (u *User) Groups() ([]string, error) {
+	if u.client.permChecker != nil {
+		return u.client.permChecker.cache.Groups(u.username)
+	}
+	return nil, nil
+}
+
+// Allow reports whether the user should be allowed to access
+// any of the users or groups in the given ACL slice.
+func (u *User) Allow(acl []string) (bool, error) {
+	if u.client.permChecker != nil {
+		return u.client.permChecker.Allow(u.username, acl)
+	}
+	// No groups - just implement the trivial cases.
+	for _, name := range acl {
+		if name == "everyone" || name == u.username {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// Id implements Identity.Id. Currently it just returns the user
+// name, but user code should not rely on it doing that - eventually
+// it will return an opaque user identifier rather than the user name.
+func (u *User) Id() string {
+	return u.username
+}
+
+// Domain implements Identity.Domain.
+// Currently it always returns the empty domain.
+func (u *User) Domain() string {
+	return ""
+}
+
+// PublicKey implements Identity.PublicKey.
+// Currently it always returns nil as identity
+// declaration caveats are not encrypted.
+func (u *User) PublicKey() *bakery.PublicKey {
+	return nil
 }
 
 // LoginMethods returns information about the available login methods

--- a/client_generated.go
+++ b/client_generated.go
@@ -5,7 +5,7 @@ package idmclient
 
 import (
 	"github.com/juju/httprequest"
-	"gopkg.in/macaroon.v1"
+	"gopkg.in/macaroon.v2-unstable"
 
 	"github.com/juju/idmclient/params"
 )

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,59 @@
+package idmclient_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery/checkers"
+	"gopkg.in/macaroon.v2-unstable"
+	"sort"
+
+	"github.com/juju/idmclient"
+	"github.com/juju/idmclient/idmtest"
+)
+
+type clientSuite struct{}
+
+var _ = gc.Suite(&clientSuite{})
+
+func (*clientSuite) TestIdentityCaveat(c *gc.C) {
+	srv := idmtest.NewServer()
+	srv.AddUser("bob", "alice", "charlie")
+	client := srv.Client("bob")
+	idmClient := srv.IDMClient("bob")
+
+	bsvc, err := bakery.NewService(bakery.NewServiceParams{
+		Locator: srv,
+	})
+	c.Assert(err, gc.IsNil)
+	m, err := bsvc.NewMacaroon(idmClient.IdentityCaveats())
+	c.Assert(err, gc.IsNil)
+
+	ms, err := client.DischargeAll(m)
+	c.Assert(err, gc.IsNil)
+
+	// Make sure that the macaroon discharged correctly and that it
+	// has the right declared caveats.
+	attrs, err := bsvc.CheckAny([]macaroon.Slice{ms}, nil, checkers.New())
+	c.Assert(err, gc.IsNil)
+
+	ident, err := idmClient.DeclaredIdentity(attrs)
+	c.Assert(err, gc.IsNil)
+
+	c.Assert(ident.Id(), gc.Equals, "bob")
+	c.Assert(ident.Domain(), gc.Equals, "")
+
+	user := ident.(*idmclient.User)
+
+	u, err := user.Username()
+	c.Assert(err, gc.IsNil)
+	c.Assert(u, gc.Equals, "bob")
+	ok, err := user.Allow([]string{"alice"})
+	c.Assert(err, gc.IsNil)
+	c.Assert(ok, gc.Equals, true)
+
+	groups, err := user.Groups()
+	c.Assert(err, gc.IsNil)
+	sort.Strings(groups)
+	c.Assert(groups, jc.DeepEquals, []string{"alice", "charlie"})
+}

--- a/idmtest/idmtest_test.go
+++ b/idmtest/idmtest_test.go
@@ -11,7 +11,6 @@ import (
 	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery"
 	"gopkg.in/macaroon.v2-unstable"
 
-	"github.com/juju/idmclient"
 	"github.com/juju/idmclient/idmtest"
 	idmparams "github.com/juju/idmclient/params"
 )
@@ -78,10 +77,7 @@ func (*suite) TestGroups(c *gc.C) {
 	srv.AddUser("bob", "beatles", "bobbins")
 	srv.AddUser("alice")
 
-	client := idmclient.New(idmclient.NewParams{
-		BaseURL: srv.URL.String(),
-		Client:  srv.Client("bob"),
-	})
+	client := srv.IDMClient("bob")
 	groups, err := client.UserGroups(&idmparams.UserGroupsRequest{
 		Username: "bob",
 	})
@@ -101,10 +97,7 @@ func (s *suite) TestAddUserWithExistingGroups(c *gc.C) {
 	srv.AddUser("alice")
 	srv.AddUser("alice", "goof", "anteaters")
 
-	client := idmclient.New(idmclient.NewParams{
-		BaseURL: srv.URL.String(),
-		Client:  srv.Client("alice"),
-	})
+	client := srv.IDMClient("alice")
 	groups, err := client.UserGroups(&idmparams.UserGroupsRequest{
 		Username: "alice",
 	})

--- a/interface.go
+++ b/interface.go
@@ -1,0 +1,44 @@
+package idmclient
+
+import (
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery/checkers"
+)
+
+// TODO move these interface declarations into the bakery repository.
+
+// IdentityClient represents an abstract identity manager. A client can
+// use this to create a third party caveat requesting authentication and
+// to decode the authentication information from the resulting discharge
+// macaroon caveats and then to find information about the resulting
+// identity.
+type IdentityClient interface {
+	// IdentityCaveats encodes identity caveats addressed to the identity
+	// service that request the service to authenticate the user.
+	IdentityCaveats() []checkers.Caveat
+
+	// DeclaredIdentity parses the identity declaration from the given
+	// declared attributes.
+	DeclaredIdentity(declared map[string]string) (Identity, error)
+}
+
+// IdentityCaveatServer represents the server side of the identity
+// service caveat contract. An identity server can use this
+// to decode third party caveats addressed to it by clients
+// and to encode the resulting username information.
+type IdentityCaveatServer interface {
+}
+
+// Identity holds identity information declared in a first party caveat
+// added when discharging a third party caveat.
+type Identity interface {
+	// Id returns the id of the user, which may be an
+	// opaque blob with no human meaning.
+	// An id is only considered to be unique
+	// with a given domain.
+	Id() string
+
+	// Domain holds the domain of the user. This
+	// will be empty if the user was authenticated
+	// directly with the identity provider.
+	Domain() string
+}

--- a/permcheck.go
+++ b/permcheck.go
@@ -9,6 +9,8 @@ import (
 	"gopkg.in/errgo.v1"
 )
 
+// TODO unexport this type - it's best exposed as part of the client API only.
+
 // PermChecker provides a way to query ACLs using the identity client.
 type PermChecker struct {
 	cache *GroupCache

--- a/permcheck_test.go
+++ b/permcheck_test.go
@@ -22,10 +22,11 @@ func (s *permCheckerSuite) TestPermChecker(c *gc.C) {
 	srv := idmtest.NewServer()
 	srv.AddUser("alice", "somegroup")
 
-	client := idmclient.New(idmclient.NewParams{
+	client, err := idmclient.New(idmclient.NewParams{
 		BaseURL: srv.URL.String(),
 		Client:  srv.Client("alice"),
 	})
+	c.Assert(err, gc.IsNil)
 
 	pc := idmclient.NewPermChecker(client, time.Hour)
 
@@ -68,10 +69,11 @@ func (s *permCheckerSuite) TestGroupCache(c *gc.C) {
 	srv := idmtest.NewServer()
 	srv.AddUser("alice", "somegroup", "othergroup")
 
-	client := idmclient.New(idmclient.NewParams{
+	client, err := idmclient.New(idmclient.NewParams{
 		BaseURL: srv.URL.String(),
 		Client:  srv.Client("alice"),
 	})
+	c.Assert(err, gc.IsNil)
 
 	cache := idmclient.NewGroupCache(client, time.Hour)
 


### PR DESCRIPTION
This creates an IdentityClient abstraction which is the start of enabling the
changes which will eventually allow unprivileged users to
be able to get groups information from third party identity
managers. It encapsulates information about how to create
an IdM third party caveat and to retrieve the identity
from declared information in the discharge macaroon.

In a future PR we'll remove the PermChecker and GroupCache types
as they're now redundant.

As a proof of concept, we changed the charmstore code to use
this (PR to come after this lands).