### PR TITLE
idmclient: add StripDomain function

### DIFF
--- a/client.go
+++ b/client.go
@@ -130,6 +130,8 @@ type User struct {
 	username string
 }
 
+var _ ACLUser = (*User)(nil)
+
 // Username returns the user name of the user.
 func (u *User) Username() (string, error) {
 	return u.username, nil
@@ -155,12 +157,8 @@ func (u *User) Allow(acl []string) (bool, error) {
 		return u.client.permChecker.Allow(u.username, acl)
 	}
 	// No groups - just implement the trivial cases.
-	for _, name := range acl {
-		if name == "everyone" || name == u.username {
-			return true, nil
-		}
-	}
-	return false, nil
+	ok, _ := trivialAllow(u.username, acl)
+	return ok, nil
 }
 
 // Id implements Identity.Id. Currently it just returns the user

--- a/client_test.go
+++ b/client_test.go
@@ -5,6 +5,7 @@ import (
 	gc "gopkg.in/check.v1"
 	"gopkg.in/macaroon-bakery.v2-unstable/bakery"
 	"gopkg.in/macaroon-bakery.v2-unstable/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery"
 	"gopkg.in/macaroon.v2-unstable"
 	"sort"
 
@@ -16,20 +17,50 @@ type clientSuite struct{}
 
 var _ = gc.Suite(&clientSuite{})
 
-func (*clientSuite) TestIdentityCaveat(c *gc.C) {
+func (*clientSuite) TestIdentityClient(c *gc.C) {
 	srv := idmtest.NewServer()
 	srv.AddUser("bob", "alice", "charlie")
-	client := srv.Client("bob")
-	idmClient := srv.IDMClient("bob")
+	testIdentityClient(c,
+		srv.IDMClient("bob"),
+		srv.Client("bob"),
+		"bob", "bob", []string{"alice", "charlie"},
+	)
+}
 
+func (*clientSuite) TestIdentityClientWithDomainStrip(c *gc.C) {
+	srv := idmtest.NewServer()
+	srv.AddUser("bob@usso", "alice@usso", "charlie@elsewhere")
+	testIdentityClient(c,
+		idmclient.StripDomain(srv.IDMClient("bob@usso"), "usso"),
+		srv.Client("bob@usso"),
+		"bob@usso", "bob", []string{"alice", "charlie@elsewhere"},
+	)
+}
+
+func (*clientSuite) TestIdentityClientWithDomainStripNoDomains(c *gc.C) {
+	srv := idmtest.NewServer()
+	srv.AddUser("bob", "alice", "charlie")
+	testIdentityClient(c,
+		idmclient.StripDomain(srv.IDMClient("bob"), "usso"),
+		srv.Client("bob"),
+		"bob", "bob", []string{"alice", "charlie"},
+	)
+}
+
+// testIdentityClient tests that the given identity client can be used to
+// create a third party caveat that when discharged provides
+// an Identity with the given id, user name and groups.
+func testIdentityClient(c *gc.C, idmClient idmclient.IdentityClient, bclient *httpbakery.Client, expectId, expectUser string, expectGroups []string) {
+	kr := httpbakery.NewPublicKeyRing(nil, nil)
+	kr.AllowInsecure()
 	bsvc, err := bakery.NewService(bakery.NewServiceParams{
-		Locator: srv,
+		Locator: kr,
 	})
 	c.Assert(err, gc.IsNil)
 	m, err := bsvc.NewMacaroon(idmClient.IdentityCaveats())
 	c.Assert(err, gc.IsNil)
 
-	ms, err := client.DischargeAll(m)
+	ms, err := bclient.DischargeAll(m)
 	c.Assert(err, gc.IsNil)
 
 	// Make sure that the macaroon discharged correctly and that it
@@ -40,20 +71,20 @@ func (*clientSuite) TestIdentityCaveat(c *gc.C) {
 	ident, err := idmClient.DeclaredIdentity(attrs)
 	c.Assert(err, gc.IsNil)
 
-	c.Assert(ident.Id(), gc.Equals, "bob")
+	c.Assert(ident.Id(), gc.Equals, expectId)
 	c.Assert(ident.Domain(), gc.Equals, "")
 
-	user := ident.(*idmclient.User)
+	user := ident.(idmclient.ACLUser)
 
 	u, err := user.Username()
 	c.Assert(err, gc.IsNil)
-	c.Assert(u, gc.Equals, "bob")
-	ok, err := user.Allow([]string{"alice"})
+	c.Assert(u, gc.Equals, expectUser)
+	ok, err := user.Allow([]string{expectGroups[0]})
 	c.Assert(err, gc.IsNil)
 	c.Assert(ok, gc.Equals, true)
 
 	groups, err := user.Groups()
 	c.Assert(err, gc.IsNil)
 	sort.Strings(groups)
-	c.Assert(groups, jc.DeepEquals, []string{"alice", "charlie"})
+	c.Assert(groups, jc.DeepEquals, expectGroups)
 }

--- a/strip.go
+++ b/strip.go
@@ -1,0 +1,130 @@
+package idmclient
+
+import (
+	"strings"
+
+	"gopkg.in/errgo.v1"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery/checkers"
+)
+
+// StripDomain wraps the given identity client and strips the given
+// domain name off any user and group names returned from it. It also
+// adds it as an @ suffix when querying for ACL membership for names
+// that don't already contain a domain.
+//
+// If the users returned from idmClient implement ACLUser, the users
+// returned from the returned client will too.
+//
+// This is useful when an existing user of the identity manager needs to
+// obtain backwardly compatible usernames when an identity manager is
+// changed to add a domain suffix.
+func StripDomain(idmClient IdentityClient, domain string) IdentityClient {
+	return &domainStrippingClient{
+		domain: "@" + domain,
+		c:      idmClient,
+	}
+}
+
+// ACLUser represents a user that can be queried for group information.
+type ACLUser interface {
+	Identity
+
+	// Username returns the user name of the user.
+	Username() (string, error)
+
+	// Groups returns all the groups that the user
+	// is a member of.
+	//
+	// Note: use of this method should be avoided if
+	// possible, as a user may potentially be in huge
+	// numbers of groups.
+	Groups() ([]string, error)
+
+	// Allow reports whether the user should be allowed to access
+	// any of the users or groups in the given ACL slice.
+	Allow(acl []string) (bool, error)
+}
+
+// domainStrippingClient implements IdentityClient by stripping a given
+// domain off any declared users.
+type domainStrippingClient struct {
+	domain string
+	c      IdentityClient
+}
+
+// DeclaredIdentity implements IdentityClient.DeclaredIdentity.
+func (c *domainStrippingClient) DeclaredIdentity(attrs map[string]string) (Identity, error) {
+	ident, err := c.c.DeclaredIdentity(attrs)
+	if err != nil {
+		return nil, err
+	}
+	u, ok := ident.(ACLUser)
+	if !ok {
+		return ident, nil
+	}
+	return &domainStrippingIdentity{
+		ACLUser: u,
+		domain:  c.domain,
+	}, nil
+}
+
+// DeclaredIdentity implements IdentityClient.IdentityCaveats.
+func (c *domainStrippingClient) IdentityCaveats() []checkers.Caveat {
+	return c.c.IdentityCaveats()
+}
+
+type domainStrippingIdentity struct {
+	domain string
+	ACLUser
+}
+
+// Username implements ACLUser.IdentityCaveats.
+func (u *domainStrippingIdentity) Username() (string, error) {
+	name, err := u.ACLUser.Username()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSuffix(name, u.domain), nil
+}
+
+// Groups implements ACLUser.Groups.
+func (u *domainStrippingIdentity) Groups() ([]string, error) {
+	groups, err := u.ACLUser.Groups()
+	if err != nil {
+		return nil, err
+	}
+	for i, g := range groups {
+		groups[i] = strings.TrimSuffix(g, u.domain)
+	}
+	return groups, nil
+}
+
+// Allow implements ACLUser.Allow by adding stripped
+// domain to all names in acl that don't have a domain
+// before calling the underlying Allow method.
+func (u *domainStrippingIdentity) Allow(acl []string) (bool, error) {
+	acl1 := make([]string, len(acl))
+	for i, name := range acl {
+		if !strings.Contains(name, "@") {
+			acl1[i] = name + u.domain
+		} else {
+			acl1[i] = name
+		}
+	}
+	ok, err := u.ACLUser.Allow(acl1)
+	if err != nil {
+		return false, errgo.Mask(err)
+	}
+	if ok {
+		return true, nil
+	}
+	// We were denied access with @usso suffix, but perhaps
+	// the identity manager isn't yet adding suffixes - we still
+	// want it to work in that case, so try without the added
+	// suffixes.
+	ok, err = u.ACLUser.Allow(acl)
+	if err != nil {
+		return false, errgo.Mask(err)
+	}
+	return ok, nil
+}


### PR DESCRIPTION
This will make it easier for services to migrate to an
identity manager that adds a domain suffix to
user names.