### PR TITLE
support everyone@domain groups

### DIFF
--- a/permcheck.go
+++ b/permcheck.go
@@ -4,6 +4,7 @@
 package idmclient
 
 import (
+	"strings"
 	"time"
 
 	"gopkg.in/errgo.v1"
@@ -43,7 +44,20 @@ func trivialAllow(username string, acl []string) (allow, isTrivial bool) {
 		return false, true
 	}
 	for _, name := range acl {
-		if name == "everyone" || name == username {
+		if name == username {
+			return true, true
+		}
+		suffix := strings.TrimPrefix(name, "everyone")
+		if len(suffix) == len(name) {
+			continue
+		}
+		if suffix != "" && suffix[0] != '@' {
+			continue
+		}
+		// name is either "everyone" or "everyone@somewhere". We consider
+		// the user to be part of everyone@somewhere if their username has
+		// the suffix @somewhere.
+		if strings.HasSuffix(username, suffix) {
 			return true, true
 		}
 	}

--- a/permcheck_test.go
+++ b/permcheck_test.go
@@ -45,6 +45,22 @@ func (s *permCheckerSuite) TestPermChecker(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	c.Assert(ok, gc.Equals, true)
 
+	// If the perms allow everyone@somewhere, it's ok.
+	ok, err = pc.Allow("bob@somewhere", []string{"everyone@somewhere"})
+	c.Assert(err, gc.IsNil)
+	c.Assert(ok, gc.Equals, true)
+
+	// Check that the everyone@x logic works with multiple @s.
+	ok, err = pc.Allow("bob@foo@somewhere@else", []string{"everyone@somewhere@else"})
+	c.Assert(err, gc.IsNil)
+	c.Assert(ok, gc.Equals, true)
+
+	// Check that we're careful enough about "everyone" as a prefix
+	// to a user name.
+	ok, err = pc.Allow("bobx", []string{"everyonex"})
+	c.Assert(err, gc.IsNil)
+	c.Assert(ok, gc.Equals, false)
+
 	// If the perms allow the user itself, it's ok
 	ok, err = pc.Allow("bob", []string{"noone", "bob"})
 	c.Assert(err, gc.IsNil)


### PR DESCRIPTION
This allows an ACL to select users that have authenticated in a particular domain.
