### PR TITLE
add CreateAgent endpoint

### DIFF
--- a/client_generated.go
+++ b/client_generated.go
@@ -6,13 +6,20 @@ package idmclient
 import (
 	"golang.org/x/net/context"
 	"gopkg.in/httprequest.v1"
-	"gopkg.in/macaroon-bakery.v2/bakery"
-
 	"gopkg.in/juju/idmclient.v1/params"
+	"gopkg.in/macaroon-bakery.v2/bakery"
 )
 
 type client struct {
 	Client httprequest.Client
+}
+
+// CreateAgent creates a new agent and returns the newly chosen username
+// for the agent.
+func (c *client) CreateAgent(ctx context.Context, p *params.CreateAgentRequest) (*params.CreateAgentResponse, error) {
+	var r *params.CreateAgentResponse
+	err := c.Client.Call(ctx, p, &r)
+	return r, err
 }
 
 // DeleteSSHKeys removes all of the ssh keys specified from the keys
@@ -59,12 +66,13 @@ func (c *client) QueryUsers(ctx context.Context, p *params.QueryUsersRequest) ([
 	return r, err
 }
 
-// SetUser creates or updates the user with the given username. If the
+// SetUserDeprecated creates or updates the user with the given username. If the
 // user already exists then any IDPGroups or SSHKeys specified in the
 // request will be ignored. See SetUserGroups, ModifyUserGroups,
 // SetSSHKeys and DeleteSSHKeys if you wish to manipulate these for a
 // user.
-func (c *client) SetUser(ctx context.Context, p *params.SetUserRequest) error {
+// TODO change this into a create-agent function.
+func (c *client) SetUserDeprecated(ctx context.Context, p *params.SetUserRequest) error {
 	return c.Client.Call(ctx, p, nil)
 }
 

--- a/params/params.go
+++ b/params/params.go
@@ -129,11 +129,32 @@ type User struct {
 	LastDischarge *time.Time          `json:"last_discharge,omitempty"`
 }
 
-// SetUserRequest is request to set the details of a user.
+// SetUserRequest is a request to set the details of a user.
+// This endpoint is no longer functional.
 type SetUserRequest struct {
 	httprequest.Route `httprequest:"PUT /v1/u/:username"`
 	Username          Username `httprequest:"username,path"`
 	User              `httprequest:",body"`
+}
+
+// CreateAgentRequest is a request to add an agent.
+type CreateAgentRequest struct {
+	httprequest.Route `httprequest:"POST /v1/u"`
+	CreateAgentBody   `httprequest:",body"`
+}
+
+// CreateAgentBody holds the body of a CreateAgentRequest.
+// There must be at least one public key specified.
+type CreateAgentBody struct {
+	FullName   string              `json:"fullname"`
+	Groups     []string            `json:"idpgroups"`
+	PublicKeys []*bakery.PublicKey `json:"public_keys"`
+}
+
+// CreateAgentResponse holds the response from a
+// CreateAgentRequest.
+type CreateAgentResponse struct {
+	Username Username
 }
 
 // UserGroupsRequest is a request for the list of groups associated


### PR DESCRIPTION
This is a backwardly incompatible change because we're removing SetUser, but no clients that we care about should be using the entry points that we've changed.