### PR TITLE
feat: make io filler constructor

### DIFF
--- a/ussologin/ussologin.go
+++ b/ussologin/ussologin.go
@@ -7,6 +7,7 @@ package ussologin
 
 import (
 	"encoding/json"
+	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -30,6 +31,14 @@ var (
 	passKey = "Password"
 	otpKey  = "Two-factor auth (Enter for none)"
 )
+
+// MakeIOFiller returns a form filler that reads from in and writes to out.
+func MakeIOFiller(in io.Reader, out io.Writer) form.Filler {
+	return form.IOFiller{
+		In:  in,
+		Out: out,
+	}
+}
 
 // A FormTokenGetter is a TokenGetter implementation that presents a form
 // to the user to get login details, and then uses those to get a token


### PR DESCRIPTION
Adding this constructor allows us to remove the direct dependency on the environschema package. The idmclient can offer out a form.Filler using the environschema package, with the right std io dependencies. Thus we only directly depend on std lib io package.

Once we remove macaroons in the distant future, we can just rip out the idm client et al and we won't depend on this or the environschema anymore.